### PR TITLE
Add relationConfig public variable to allow extending by plugins

### DIFF
--- a/controllers/Users.php
+++ b/controllers/Users.php
@@ -17,6 +17,7 @@ class Users extends Controller
 
     public $listConfig = 'config_list.yaml';
     public $formConfig = 'config_form.yaml';
+    public $relationConfig;
 
     /**
      * Users constructor.


### PR DESCRIPTION
### Problem
When I want to extend the [Users controller](https://github.com/oc-shopaholic/oc-buddies-plugin/blob/master/controllers/Users.php) by relations and add `Backend.Behaviors.RelationController`, I'm getting error:

```
Class Lovata\Buddies\Controllers\Users must define property $relationConfig used by Backend\Behaviors\RelationController behavior.
```

Tried to add relationConfig from outside, but not worked:

```
Users::extend(function ($controller) {
    $controller->implement[] = 'Backend.Behaviors.RelationController';
    $controller->relationConfig = __DIR__ . '/config/lovata_buddies_users_relations.yaml';
});
```

### Solution
Inspired by RainLab.User [Users controller](https://github.com/rainlab/user-plugin/blob/master/controllers/Users.php) simply add `$relationConfig`.

See more https://github.com/rainlab/user-plugin/commit/9bbec48184bc53c46ece48fb444de416af1be342